### PR TITLE
Moved caf-correlation into separate repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# CAF Correlation
+
+Manifest of the components which make up the CAF Correlation libraries:
+* [caf-correlation-constants](caf-correlation-constants)
+* [caf-correlation-dropwizard](caf-correlation-dropwizard)
+* [caf-correlation-jaxrs](caf-correlation-jaxrs)
+* [caf-correlation-jservlet](caf-correlation-jservlet)
+* [caf-correlation-spring](caf-correlation-spring)
+* [caf-correlation-spring-tests](caf-correlation-spring-tests)

--- a/caf-correlation-constants/README.md
+++ b/caf-correlation-constants/README.md
@@ -1,0 +1,6 @@
+## CAF Correlation Constants
+This module exposes the constants which can be used by the consumers of this library.
+
+### Constants 
+<br/> HEADER_KEY - This key is used to pass around correlation id in the request and response headers. 
+<br/> MDC_KEY - This key is used to set the correlation id in the MDC context.

--- a/caf-correlation-constants/pom.xml
+++ b/caf-correlation-constants/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2021 Micro Focus or one of its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.cafapi.correlation</groupId>
+        <artifactId>caf-correlation</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>caf-correlation-constants</artifactId>
+
+</project>

--- a/caf-correlation-constants/src/main/java/com/github/cafapi/correlation/constants/CorrelationIdConfigurationConstants.java
+++ b/caf-correlation-constants/src/main/java/com/github/cafapi/correlation/constants/CorrelationIdConfigurationConstants.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cafapi.correlation.constants;
+
+public final class CorrelationIdConfigurationConstants
+{
+    private CorrelationIdConfigurationConstants()
+    {
+    }
+
+    public static final String HEADER_NAME = "CAF-Correlation-Id";
+    public static final String MDC_KEY = "correlationId";
+}

--- a/caf-correlation-dropwizard/README.md
+++ b/caf-correlation-dropwizard/README.md
@@ -1,0 +1,15 @@
+# CAF Correlation Dropwizard
+
+This module includes a dropwizard bundle which encapsulates a `javax.servlet.Filter` implementation for managing the correlation id in dropwizard applications.
+
+## How it works
+The filter gets correlation id from incoming request(or creates one if it doesn't exist) and sets it into the MDC context. In addition to that it also adds the correlation id to the outgoing response header. 
+
+## Usage 
+Add bundle to your dropwizard configuration
+
+```
+public void initialize(Bootstrap<MyApplicationConfiguration> bootstrap) {
+    bootstrap.addBundle(new CorrelationIdBundle<>()));
+}
+```

--- a/caf-correlation-dropwizard/pom.xml
+++ b/caf-correlation-dropwizard/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2021 Micro Focus or one of its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.cafapi.correlation</groupId>
+        <artifactId>caf-correlation</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>caf-correlation-dropwizard</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.cafapi.correlation</groupId>
+            <artifactId>caf-correlation-jservlet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-jetty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.cafapi.correlation</groupId>
+            <artifactId>caf-correlation-constants</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-jersey</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/caf-correlation-dropwizard/src/main/java/com/github/cafapi/correlation/dropwizard/CorrelationIdBundle.java
+++ b/caf-correlation-dropwizard/src/main/java/com/github/cafapi/correlation/dropwizard/CorrelationIdBundle.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cafapi.correlation.dropwizard;
+
+import com.github.cafapi.correlation.jservlet.CorrelationIdFilter;
+import io.dropwizard.Configuration;
+import io.dropwizard.ConfiguredBundle;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import java.util.EnumSet;
+import javax.servlet.DispatcherType;
+
+public class CorrelationIdBundle<C extends Configuration> implements ConfiguredBundle<C>
+{
+    @Override
+    public void initialize(final Bootstrap<?> bootstrap)
+    {
+    }
+
+    @Override
+    public void run(final C configuration, final Environment environment)
+    {
+        environment.servlets()
+            .addFilter("correlation-id-servlet-filter", new CorrelationIdFilter())
+            .addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), false, "*");
+    }
+}

--- a/caf-correlation-dropwizard/src/test/java/com/github/cafapi/correlation/dropwizard/tests/CorrelationIdDropwizardTest.java
+++ b/caf-correlation-dropwizard/src/test/java/com/github/cafapi/correlation/dropwizard/tests/CorrelationIdDropwizardTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cafapi.correlation.dropwizard.tests;
+
+import static com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants.HEADER_NAME;
+import com.github.cafapi.correlation.dropwizard.CorrelationIdBundle;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+final class CorrelationIdDropwizardTest
+{
+    private static final DropwizardAppExtension<Configuration> EXT = new DropwizardAppExtension<>(TestApp.class, new Configuration());
+
+    @Test
+    void testCorrelationIdIsAddedIfNotPresentInRequest()
+    {
+        final Client client = EXT.client();
+
+        final Response response = client.target(
+            String.format("http://localhost:%d/ping", EXT.getLocalPort()))
+            .request()
+            .get();
+
+        Assertions.assertNotNull(response.getHeaders().get(HEADER_NAME));
+    }
+
+    @Test
+    void testRequestWithHeader()
+    {
+        final Client client = EXT.client();
+
+        final Response response = client.target(
+            String.format("http://localhost:%d/ping", EXT.getLocalPort()))
+            .request()
+            .header(HEADER_NAME, "UUID1")
+            .get();
+
+        Assertions.assertEquals("UUID1", response.getHeaders().get(HEADER_NAME).get(0));
+        Assertions.assertEquals(1, response.getHeaders().get(HEADER_NAME).size());
+    }
+
+    public static final class TestApp extends Application<Configuration>
+    {
+        @Override
+        public void initialize(final Bootstrap<Configuration> bootstrap)
+        {
+            bootstrap.addBundle(new CorrelationIdBundle<>());
+        }
+
+        @Override
+        public void run(final Configuration configuration, final Environment environment)
+        {
+            environment.jersey().register(this);
+            environment.jersey().register(new PingResource());
+        }
+    }
+
+    @Path("/ping")
+    public static final class PingResource
+    {
+        @GET
+        public String ping()
+        {
+            return "pong";
+        }
+    }
+}

--- a/caf-correlation-jaxrs/README.md
+++ b/caf-correlation-jaxrs/README.md
@@ -1,0 +1,8 @@
+# CAF Correlation JAXRS
+This module encapsulates an implementation of `javax.ws.rs.client.ClientRequestFilter`. This client filter when registered with the client would set the correlation id in the outgoing request's header. The filter gets the correlation id from the MDC context(or creates one if it doesn't  find one).
+
+## Usage
+```
+Client client = builder.build(...);
+client.register(new CorrelationIdClientFilter(configuration));
+``` 

--- a/caf-correlation-jaxrs/pom.xml
+++ b/caf-correlation-jaxrs/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2021 Micro Focus or one of its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.cafapi.correlation</groupId>
+        <artifactId>caf-correlation</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>caf-correlation-jaxrs</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.cafapi.correlation</groupId>
+            <artifactId>caf-correlation-constants</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/caf-correlation-jaxrs/src/main/java/com/github/cafapi/correlation/jaxrs/CorrelationIdClientFilter.java
+++ b/caf-correlation-jaxrs/src/main/java/com/github/cafapi/correlation/jaxrs/CorrelationIdClientFilter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cafapi.correlation.jaxrs;
+
+import static com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants.HEADER_NAME;
+import static com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants.MDC_KEY;
+import java.util.Optional;
+import java.util.UUID;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.ext.Provider;
+import org.slf4j.MDC;
+
+@Provider
+public class CorrelationIdClientFilter implements ClientRequestFilter
+{
+    @Override
+    public void filter(final ClientRequestContext requestContext)
+    {
+        final String correlationId = Optional.ofNullable(MDC.get(MDC_KEY)).orElseGet(() -> UUID.randomUUID().toString());
+        requestContext.getHeaders().add(HEADER_NAME, correlationId);
+    }
+}

--- a/caf-correlation-jservlet/README.md
+++ b/caf-correlation-jservlet/README.md
@@ -1,0 +1,19 @@
+# CAF Correlation JServlet
+This module encapsulates an implementation of `javax.servlet.Filter` which manages the Correlation id for the which uses this filter.
+
+## How it works
+The filter gets correlation id from incoming request(or creates one if it doesn't exist) and sets it into the MDC context. In addition to that it also adds the correlation id to the outgoing response header.
+
+## Usage
+This filter can be added in web.xml as mentioned below
+
+```
+  <filter>
+    <filter-name>CorrelationIdFilter</filter-name>
+    <filter-class>com.github.cafapi.correlation.jservlet.CorrelationIdFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>CorrelationIdFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+```

--- a/caf-correlation-jservlet/pom.xml
+++ b/caf-correlation-jservlet/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2021 Micro Focus or one of its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.cafapi.correlation</groupId>
+        <artifactId>caf-correlation</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>caf-correlation-jservlet</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.cafapi.correlation</groupId>
+            <artifactId>caf-correlation-constants</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/caf-correlation-jservlet/src/main/java/com/github/cafapi/correlation/jservlet/CorrelationIdFilter.java
+++ b/caf-correlation-jservlet/src/main/java/com/github/cafapi/correlation/jservlet/CorrelationIdFilter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cafapi.correlation.jservlet;
+
+import com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+
+public class CorrelationIdFilter implements Filter
+{
+    @Override
+    public void init(final FilterConfig filterConfig)
+    {
+    }
+
+    @Override
+    public void doFilter(
+        final ServletRequest request,
+        final ServletResponse response,
+        final FilterChain chain
+    ) throws IOException, ServletException
+    {
+        final HttpServletRequest req = (HttpServletRequest) request;
+        final HttpServletResponse resp = (HttpServletResponse) response;
+        final String correlationId = Optional.ofNullable(req.getHeader(CorrelationIdConfigurationConstants.HEADER_NAME))
+            .orElseGet(() -> UUID.randomUUID().toString());
+        MDC.put(CorrelationIdConfigurationConstants.MDC_KEY, correlationId);
+        resp.addHeader(CorrelationIdConfigurationConstants.HEADER_NAME, correlationId);
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy()
+    {
+    }
+}

--- a/caf-correlation-spring-tests/README.md
+++ b/caf-correlation-spring-tests/README.md
@@ -1,0 +1,2 @@
+# CAF Correlation Spring Tests
+This module contains tests related to caf-correlation-spring project.

--- a/caf-correlation-spring-tests/pom.xml
+++ b/caf-correlation-spring-tests/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2021 Micro Focus or one of its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.cafapi.correlation</groupId>
+        <artifactId>caf-correlation</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>caf-correlation-spring-tests</artifactId>
+
+    <properties>
+        <maven.install.skip>true</maven.install.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+    </properties>
+
+    <dependencies>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>com.github.cafapi.correlation</groupId>
+            <artifactId>caf-correlation-constants</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.cafapi.correlation</groupId>
+            <artifactId>caf-correlation-jaxrs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.cafapi.correlation</groupId>
+            <artifactId>caf-correlation-spring</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+        </dependency>
+
+        <!-- Runtime-Only Test Dependencies -->
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>aopalliance-repackaged</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <testClassesDirectory>${project.build.outputDirectory}</testClassesDirectory>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/caf-correlation-spring-tests/src/main/java/com/github/cafapi/correlation/spring/tests/GreetingController.java
+++ b/caf-correlation-spring-tests/src/main/java/com/github/cafapi/correlation/spring/tests/GreetingController.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cafapi.correlation.spring.tests;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public final class GreetingController
+{
+    @RequestMapping("/greeting")
+    public @ResponseBody
+    String greeting()
+    {
+        return "Hello !!!";
+    }
+}

--- a/caf-correlation-spring-tests/src/main/java/com/github/cafapi/correlation/spring/tests/TestingWebApplication.java
+++ b/caf-correlation-spring-tests/src/main/java/com/github/cafapi/correlation/spring/tests/TestingWebApplication.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cafapi.correlation.spring.tests;
+
+import com.github.cafapi.correlation.spring.CorrelationIdInterceptor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@SpringBootApplication(scanBasePackages = {"com.filter.http.spring"})
+public class TestingWebApplication implements WebMvcConfigurer
+{
+    public static void main(final String[] args)
+    {
+        SpringApplication.run(TestingWebApplication.class, args);
+    }
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry)
+    {
+        registry.addInterceptor(new CorrelationIdInterceptor());
+    }
+}

--- a/caf-correlation-spring-tests/src/main/java/com/github/cafapi/correlation/spring/tests/TestingWebApplication.java
+++ b/caf-correlation-spring-tests/src/main/java/com/github/cafapi/correlation/spring/tests/TestingWebApplication.java
@@ -21,7 +21,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@SpringBootApplication(scanBasePackages = {"com.filter.http.spring"})
+@SpringBootApplication(scanBasePackages = {"com.github.cafapi.correlation.spring"})
 public class TestingWebApplication implements WebMvcConfigurer
 {
     public static void main(final String[] args)

--- a/caf-correlation-spring-tests/src/main/java/com/github/cafapi/correlation/spring/tests/TestingWebApplicationTests.java
+++ b/caf-correlation-spring-tests/src/main/java/com/github/cafapi/correlation/spring/tests/TestingWebApplicationTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cafapi.correlation.spring.tests;
+
+import static com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants.HEADER_NAME;
+import static com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants.MDC_KEY;
+import com.github.cafapi.correlation.jaxrs.CorrelationIdClientFilter;
+import java.util.UUID;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public final class TestingWebApplicationTests
+{
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    public void contextLoads()
+    {
+    }
+
+    @Test
+    public void testInterceptor()
+    {
+        //prepare
+        final HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add(HEADER_NAME, "UUID1");
+        final HttpEntity<?> request = new HttpEntity<>(httpHeaders);
+
+        //act
+        final HttpEntity<String> responseEntity
+            = this.restTemplate.exchange("http://localhost:" + port + "/greeting", HttpMethod.GET, request, String.class);
+
+        //assert
+        final String correlationID = responseEntity.getHeaders().get(HEADER_NAME).get(0);
+        Assertions.assertThat(correlationID).isNotNull();
+        Assertions.assertThat(correlationID).isEqualTo("UUID1");
+    }
+
+    @Test
+    public void testClientFilter()
+    {
+        //prepare
+        final Client client = ClientBuilder.newClient();
+        final String UUIDValue = UUID.randomUUID().toString();
+        MDC.put(MDC_KEY, UUIDValue);
+        client.register(new CorrelationIdClientFilter());
+
+        //act
+        final Response response = client
+            .target("http://localhost:" + port + "/greeting")
+            .request()
+            .get();
+
+        //assert
+        Assertions.assertThat(response.getHeaders().get(HEADER_NAME)).isNotNull();
+        Assertions.assertThat(response.getHeaders().get(HEADER_NAME).get(0)).isEqualTo(UUIDValue);
+        Assertions.assertThat(response.getHeaders().get(HEADER_NAME).size()).isEqualTo(1);
+    }
+}

--- a/caf-correlation-spring/README.md
+++ b/caf-correlation-spring/README.md
@@ -1,0 +1,19 @@
+# CAF Correlation Spring
+This module contains spring framework's interceptor implementation for managing correlation id. This library can be used for Spring boot applications where it is required for the  correlation id to be available in MDC context for logging.
+
+## How it works
+This interceptor reads the correlation id from incoming request's header. If present, it is then added to the MDC context as well as to the outgoing response's header.
+
+## Usage
+
+```
+public class SpringApplication implements WebMvcConfigurer {
+    
+    // Excluding rest of the code for brevity 
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(new CorrelationIdInterceptor());
+    }
+}
+```

--- a/caf-correlation-spring/pom.xml
+++ b/caf-correlation-spring/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2021 Micro Focus or one of its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.cafapi.correlation</groupId>
+        <artifactId>caf-correlation</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>caf-correlation-spring</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.cafapi.correlation</groupId>
+            <artifactId>caf-correlation-constants</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/caf-correlation-spring/src/main/java/com/github/cafapi/correlation/spring/CorrelationIdInterceptor.java
+++ b/caf-correlation-spring/src/main/java/com/github/cafapi/correlation/spring/CorrelationIdInterceptor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cafapi.correlation.spring;
+
+import static com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants.HEADER_NAME;
+import static com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants.MDC_KEY;
+import java.util.Objects;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+public final class CorrelationIdInterceptor extends HandlerInterceptorAdapter
+{
+    @Override
+    public boolean preHandle(
+        final HttpServletRequest request,
+        final HttpServletResponse response,
+        final Object handler
+    )
+    {
+        final String correlationId = request.getHeader(HEADER_NAME);
+        if (Objects.nonNull(correlationId) && !correlationId.isEmpty()) {
+            MDC.put(MDC_KEY, correlationId);
+            response.setHeader(HEADER_NAME, correlationId);
+        }
+        return true;
+    }
+
+    @Override
+    public void postHandle(
+        final HttpServletRequest request,
+        final HttpServletResponse response,
+        final Object handler,
+        final ModelAndView modelAndView
+    )
+    {
+        MDC.remove(MDC_KEY);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2021 Micro Focus or one of its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.cafapi</groupId>
+        <artifactId>caf-common-parent</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+        <relativePath />
+    </parent>
+
+    <groupId>com.github.cafapi.correlation</groupId>
+    <artifactId>caf-correlation</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <description>CAF Correlation Id Modules</description>
+    <url>https://github.com/CAFapi/caf-correlation</url>
+
+    <inceptionYear>2021</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>dermot-hardy</id>
+            <name>Dermot Hardy</name>
+            <email>dermot.hardy@microfocus.com</email>
+        </developer>
+        <developer>
+            <id>simranjeetc</id>
+            <name>Simranjeet Singh Chawla</name>
+            <email>Simranjeet.SinghChawla@microfocus.com</email>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/CAFapi/caf-correlation.git</connection>
+        <developerConnection>scm:git:https://github.com/CAFapi/caf-correlation.git</developerConnection>
+        <url>https://github.com/CAFapi/caf-correlation</url>
+    </scm>
+
+    <modules>
+        <module>caf-correlation-constants</module>
+        <module>caf-correlation-jaxrs</module>
+        <module>caf-correlation-jservlet</module>
+        <module>caf-correlation-spring</module>
+        <module>caf-correlation-spring-tests</module>
+        <module>caf-correlation-dropwizard</module>
+    </modules>
+
+    <properties>
+        <copyrightYear>2021</copyrightYear>
+        <copyrightNotice>Copyright ${copyrightYear} Micro Focus or one of its affiliates.</copyrightNotice>
+        <enforceCorrectDependencies>true</enforceCorrectDependencies>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-dependencies</artifactId>
+                <version>2.0.19</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>2.4.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.github.cafapi.correlation</groupId>
+                <artifactId>caf-correlation-constants</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.cafapi.correlation</groupId>
+                <artifactId>caf-correlation-jaxrs</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.cafapi.correlation</groupId>
+                <artifactId>caf-correlation-jservlet</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.cafapi.correlation</groupId>
+                <artifactId>caf-correlation-spring</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>


### PR DESCRIPTION
1. Moved caf-correlation into separate repository
2. Removed the "-id" occurrence from various module/artifact names 
3. Changes the version number from 1.4.0 to 1.0.0
