### PR TITLE
SCMOD - 12345 Updated logic to generate correlation id even if an empty correlation id header is provided

### DIFF
--- a/caf-correlation-dropwizard/src/test/java/com/github/cafapi/correlation/dropwizard/tests/CorrelationIdDropwizardTest.java
+++ b/caf-correlation-dropwizard/src/test/java/com/github/cafapi/correlation/dropwizard/tests/CorrelationIdDropwizardTest.java
@@ -50,6 +50,37 @@ final class CorrelationIdDropwizardTest
     }
 
     @Test
+    void testCorrelationIdIsAddedIfNullCorrelationInRequest()
+    {
+        final Client client = EXT.client();
+
+        final Response response = client.target(
+            String.format("http://localhost:%d/ping", EXT.getLocalPort()))
+            .request()
+            .header(HEADER_NAME, null)
+            .get();
+
+        Assertions.assertNotNull(response.getHeaders().get(HEADER_NAME));
+        Assertions.assertNotNull(response.getHeaders().get(HEADER_NAME).get(0));
+    }
+
+    @Test
+    void testCorrelationIdIsAddedIfEmptyCorrelationInRequest()
+    {
+        final Client client = EXT.client();
+
+        final Response response = client.target(
+            String.format("http://localhost:%d/ping", EXT.getLocalPort()))
+            .request()
+            .header(HEADER_NAME, "")
+            .get();
+
+        String correlationIdFromResponse = (String) response.getHeaders().get(HEADER_NAME).get(0);
+        Assertions.assertNotNull(correlationIdFromResponse);
+        Assertions.assertNotEquals("", correlationIdFromResponse);
+    }
+
+    @Test
     void testRequestWithHeader()
     {
         final Client client = EXT.client();

--- a/caf-correlation-jservlet/src/main/java/com/github/cafapi/correlation/jservlet/CorrelationIdFilter.java
+++ b/caf-correlation-jservlet/src/main/java/com/github/cafapi/correlation/jservlet/CorrelationIdFilter.java
@@ -46,6 +46,7 @@ public class CorrelationIdFilter implements Filter
         final HttpServletRequest req = (HttpServletRequest) request;
         final HttpServletResponse resp = (HttpServletResponse) response;
         final String correlationId = Optional.ofNullable(req.getHeader(CorrelationIdConfigurationConstants.HEADER_NAME))
+            .filter(s -> !s.isEmpty())
             .orElseGet(() -> UUID.randomUUID().toString());
         MDC.put(CorrelationIdConfigurationConstants.MDC_KEY, correlationId);
         resp.addHeader(CorrelationIdConfigurationConstants.HEADER_NAME, correlationId);


### PR DESCRIPTION
https://portal.digitalsafe.net/browse/SCMOD-12345