### PR TITLE
SCMOD 12345: Generate correlationId in Spring services

### DIFF
--- a/caf-correlation-jservlet/src/main/java/com/github/cafapi/correlation/jservlet/CorrelationIdFilter.java
+++ b/caf-correlation-jservlet/src/main/java/com/github/cafapi/correlation/jservlet/CorrelationIdFilter.java
@@ -15,7 +15,9 @@
  */
 package com.github.cafapi.correlation.jservlet;
 
-import com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants;
+import static com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants.HEADER_NAME;
+import static com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants.MDC_KEY;
+
 import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
@@ -45,11 +47,11 @@ public class CorrelationIdFilter implements Filter
     {
         final HttpServletRequest req = (HttpServletRequest) request;
         final HttpServletResponse resp = (HttpServletResponse) response;
-        final String correlationId = Optional.ofNullable(req.getHeader(CorrelationIdConfigurationConstants.HEADER_NAME))
+        final String correlationId = Optional.ofNullable(req.getHeader(HEADER_NAME))
             .filter(s -> !s.isEmpty())
             .orElseGet(() -> UUID.randomUUID().toString());
-        MDC.put(CorrelationIdConfigurationConstants.MDC_KEY, correlationId);
-        resp.addHeader(CorrelationIdConfigurationConstants.HEADER_NAME, correlationId);
+        MDC.put(MDC_KEY, correlationId);
+        resp.addHeader(HEADER_NAME, correlationId);
         chain.doFilter(request, response);
     }
 

--- a/caf-correlation-jservlet/src/main/java/com/github/cafapi/correlation/jservlet/CorrelationIdFilter.java
+++ b/caf-correlation-jservlet/src/main/java/com/github/cafapi/correlation/jservlet/CorrelationIdFilter.java
@@ -15,9 +15,7 @@
  */
 package com.github.cafapi.correlation.jservlet;
 
-import static com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants.HEADER_NAME;
-import static com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants.MDC_KEY;
-
+import com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
@@ -47,11 +45,11 @@ public class CorrelationIdFilter implements Filter
     {
         final HttpServletRequest req = (HttpServletRequest) request;
         final HttpServletResponse resp = (HttpServletResponse) response;
-        final String correlationId = Optional.ofNullable(req.getHeader(HEADER_NAME))
+        final String correlationId = Optional.ofNullable(req.getHeader(CorrelationIdConfigurationConstants.HEADER_NAME))
             .filter(s -> !s.isEmpty())
             .orElseGet(() -> UUID.randomUUID().toString());
-        MDC.put(MDC_KEY, correlationId);
-        resp.addHeader(HEADER_NAME, correlationId);
+        MDC.put(CorrelationIdConfigurationConstants.MDC_KEY, correlationId);
+        resp.addHeader(CorrelationIdConfigurationConstants.HEADER_NAME, correlationId);
         chain.doFilter(request, response);
     }
 

--- a/caf-correlation-spring-tests/src/main/java/com/github/cafapi/correlation/spring/tests/TestingWebApplicationTests.java
+++ b/caf-correlation-spring-tests/src/main/java/com/github/cafapi/correlation/spring/tests/TestingWebApplicationTests.java
@@ -51,7 +51,7 @@ public final class TestingWebApplicationTests
     }
 
     @Test
-    public void testInterceptor()
+    public void testInterceptorWithCorrelationIdInHeader()
     {
         //prepare
         final HttpHeaders httpHeaders = new HttpHeaders();
@@ -66,6 +66,41 @@ public final class TestingWebApplicationTests
         final String correlationID = responseEntity.getHeaders().get(HEADER_NAME).get(0);
         Assertions.assertThat(correlationID).isNotNull();
         Assertions.assertThat(correlationID).isEqualTo("UUID1");
+    }
+
+    @Test
+    public void testInterceptorWithoutCorrelationIdInHeader()
+    {
+        //prepare
+        final HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add(HEADER_NAME, "");
+        final HttpEntity<?> request = new HttpEntity<>(httpHeaders);
+
+        //act
+        final HttpEntity<String> responseEntity
+            = this.restTemplate.exchange("http://localhost:" + port + "/greeting", HttpMethod.GET, request, String.class);
+
+        //assert
+        final String correlationID = responseEntity.getHeaders().get(HEADER_NAME).get(0);
+        Assertions.assertThat(correlationID).isNotNull();
+        Assertions.assertThat(correlationID).isNotEmpty();
+    }
+
+    @Test
+    public void testInterceptorWithEmptyCorrelationIdInHeader()
+    {
+        //prepare
+        final HttpHeaders httpHeaders = new HttpHeaders();
+        final HttpEntity<?> request = new HttpEntity<>(httpHeaders);
+
+        //act
+        final HttpEntity<String> responseEntity
+            = this.restTemplate.exchange("http://localhost:" + port + "/greeting", HttpMethod.GET, request, String.class);
+
+        //assert
+        final String correlationID = responseEntity.getHeaders().get(HEADER_NAME).get(0);
+        Assertions.assertThat(correlationID).isNotNull();
+        Assertions.assertThat(correlationID).isNotEmpty();
     }
 
     @Test

--- a/caf-correlation-spring/src/main/java/com/github/cafapi/correlation/spring/CorrelationIdInterceptor.java
+++ b/caf-correlation-spring/src/main/java/com/github/cafapi/correlation/spring/CorrelationIdInterceptor.java
@@ -17,7 +17,9 @@ package com.github.cafapi.correlation.spring;
 
 import static com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants.HEADER_NAME;
 import static com.github.cafapi.correlation.constants.CorrelationIdConfigurationConstants.MDC_KEY;
-import java.util.Objects;
+
+import java.util.Optional;
+import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.slf4j.MDC;
@@ -33,11 +35,11 @@ public final class CorrelationIdInterceptor extends HandlerInterceptorAdapter
         final Object handler
     )
     {
-        final String correlationId = request.getHeader(HEADER_NAME);
-        if (Objects.nonNull(correlationId) && !correlationId.isEmpty()) {
-            MDC.put(MDC_KEY, correlationId);
-            response.setHeader(HEADER_NAME, correlationId);
-        }
+        final String correlationId = Optional.ofNullable(request.getHeader(HEADER_NAME))
+            .filter(s -> !s.isEmpty())
+            .orElseGet(() -> UUID.randomUUID().toString());
+        MDC.put(MDC_KEY, correlationId);
+        response.setHeader(HEADER_NAME, correlationId);
         return true;
     }
 


### PR DESCRIPTION
Added logic to generate correlation id even if one has not been provided.